### PR TITLE
로그인 정보 받아오기 관련 오류 전부 해결, 및 기능추가

### DIFF
--- a/src/main/java/com/semi/lynk/function/notice_board/controller/NoticeController.java
+++ b/src/main/java/com/semi/lynk/function/notice_board/controller/NoticeController.java
@@ -2,6 +2,7 @@ package com.semi.lynk.function.notice_board.controller;
 
 import com.semi.lynk.function.notice_board.model.dto.NoticeDTO;
 import com.semi.lynk.function.notice_board.service.NoticeService;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,8 +43,11 @@ public class NoticeController {
     }
 
     @PostMapping("/create")
-    public String createNotice(@ModelAttribute("noticeDTO") NoticeDTO noticeDTO) {
+    public String createNotice(@ModelAttribute("noticeDTO") NoticeDTO noticeDTO, HttpSession session) {
+        String empNo = (String) session.getAttribute("empNo");
         noticeDTO.setNoticeDate(LocalDateTime.now());
+        noticeDTO.setEmployeeNo(empNo);
+        noticeDTO.setViewerCount(1);
         noticeService.createNotice(noticeDTO);
         return "redirect:/notice/list";
     }
@@ -52,6 +56,7 @@ public class NoticeController {
     public String viewNotice(@PathVariable("noticeNo") Long noticeNo, Model model) {
         noticeService.updateViewCnt(noticeNo);
         model.addAttribute("notice", noticeService.getNoticeById(noticeNo));
+        System.out.println("model = " + model);
         return "function/notice_board/view";
     }
 

--- a/src/main/java/com/semi/lynk/function/notice_board/controller/NoticeController.java
+++ b/src/main/java/com/semi/lynk/function/notice_board/controller/NoticeController.java
@@ -24,7 +24,7 @@ public class NoticeController {
     @GetMapping("/list")
     public String listNotices(Model model,
                               @RequestParam(defaultValue = "0") int page,
-                              @RequestParam(defaultValue = "10") int size) {
+                              @RequestParam(defaultValue = "13") int size) {
         Page<NoticeDTO> noticePage = noticeService.getAllNoticesPaged(page, size);
 
         model.addAttribute("notices", noticePage.getContent());

--- a/src/main/java/com/semi/lynk/function/notice_board/model/dto/NoticeDTO.java
+++ b/src/main/java/com/semi/lynk/function/notice_board/model/dto/NoticeDTO.java
@@ -18,4 +18,5 @@ public class NoticeDTO {
     private int noticeHide;
     private int viewerCount;
     private String employeeNo;
+    private String employeeName;
 }

--- a/src/main/java/com/semi/lynk/function/notice_board/model/dto/NoticeDTO.java.rej
+++ b/src/main/java/com/semi/lynk/function/notice_board/model/dto/NoticeDTO.java.rej
@@ -1,0 +1,7 @@
+diff a/src/main/java/com/semi/lynk/function/notice_board/model/dto/NoticeDTO.java b/src/main/java/com/semi/lynk/function/notice_board/model/dto/NoticeDTO.java	(rejected hunks)
+@@ -18,4 +18,5 @@
+     private int noticeHide;
+     private int viewerCount;
+     private String employeeNo;
++    private String employeeName;
+ }

--- a/src/main/java/com/semi/lynk/function/notice_board/model/dto/NoticeDTO.java.rej
+++ b/src/main/java/com/semi/lynk/function/notice_board/model/dto/NoticeDTO.java.rej
@@ -1,7 +1,0 @@
-diff a/src/main/java/com/semi/lynk/function/notice_board/model/dto/NoticeDTO.java b/src/main/java/com/semi/lynk/function/notice_board/model/dto/NoticeDTO.java	(rejected hunks)
-@@ -18,4 +18,5 @@
-     private int noticeHide;
-     private int viewerCount;
-     private String employeeNo;
-+    private String employeeName;
- }

--- a/src/main/java/com/semi/lynk/function/notice_board/service/NoticeServiceImpl.java
+++ b/src/main/java/com/semi/lynk/function/notice_board/service/NoticeServiceImpl.java
@@ -27,6 +27,7 @@ public class NoticeServiceImpl implements NoticeService {
             } else if (a.getNoticeHide() != 2 && b.getNoticeHide() == 2) {
                 return 1;
             }
+            System.out.println("a = " + a);
             return 0;
         });
 

--- a/src/main/java/com/semi/lynk/function/notice_board/service/NoticeServiceImpl.java
+++ b/src/main/java/com/semi/lynk/function/notice_board/service/NoticeServiceImpl.java
@@ -27,7 +27,6 @@ public class NoticeServiceImpl implements NoticeService {
             } else if (a.getNoticeHide() != 2 && b.getNoticeHide() == 2) {
                 return 1;
             }
-            System.out.println("a = " + a);
             return 0;
         });
 
@@ -67,7 +66,6 @@ public class NoticeServiceImpl implements NoticeService {
 
     @Override
     public void updateViewCnt(Long noticeNo) {
-        System.out.println("여기 오니?");
         noticeMapper.updateViewCnt(noticeNo);
     }
 

--- a/src/main/resources/mappers/notice_board/noticeMapper.xml
+++ b/src/main/resources/mappers/notice_board/noticeMapper.xml
@@ -32,7 +32,7 @@
 
     <select id="selectNoticeById" parameterType="Long" resultMap="noticeResultMap">
         SELECT
-        notice_date, notice_vote, notice_title, notice_content, notice_hide, viewer_count, employee_no, employee_name
+        notice_no, notice_date, notice_vote, notice_title, notice_content, notice_hide, viewer_count, employee_no, employee_name
         FROM
         notice join employee using(employee_no)
         WHERE notice_no = #{noticeNo}

--- a/src/main/resources/mappers/notice_board/noticeMapper.xml
+++ b/src/main/resources/mappers/notice_board/noticeMapper.xml
@@ -13,6 +13,7 @@
         <result property="noticeHide" column="notice_hide"/>
         <result property="viewerCount" column="viewer_count"/>
         <result property="employeeNo" column="employee_no"/>
+        <result property="employeeName" column="employee_name"/>
     </resultMap>
 
     <insert id="insertNotice" parameterType="com.semi.lynk.function.notice_board.model.dto.NoticeDTO">
@@ -22,15 +23,19 @@
 
     <select id="getAllNotices" resultMap="noticeResultMap">
         SELECT
-        *
+        notice_no, notice_date, notice_vote, notice_title, notice_content, notice_hide, viewer_count, employee_no, employee_name
         FROM
-        notice
+        notice join employee using(employee_no)
         ORDER BY
         notice_date DESC
     </select>
 
     <select id="selectNoticeById" parameterType="Long" resultMap="noticeResultMap">
-        SELECT * FROM notice WHERE notice_no = #{noticeNo}
+        SELECT
+        notice_date, notice_vote, notice_title, notice_content, notice_hide, viewer_count, employee_no, employee_name
+        FROM
+        notice join employee using(employee_no)
+        WHERE notice_no = #{noticeNo}
     </select>
 
     <update id="updateNotice" parameterType="com.semi.lynk.function.notice_board.model.dto.NoticeDTO">

--- a/src/main/resources/templates/function/notice_board/create.html
+++ b/src/main/resources/templates/function/notice_board/create.html
@@ -94,11 +94,11 @@
                     </select>
                 </div>
                 <div>
-                    <label for="employeeNo">작성자 사번:</label>
-                    <input type="text" id="employeeNo" th:field="*{employeeNo}" required>
+                    작성자 : <span th:text="${session.empName}" style="font-weight: 800; font-size: 20px">Employee Name</span>
                 </div>
+                <input type="hidden" th:field="*{employeeNo}" required>
                 <input type="hidden" th:field="*{noticeDate}">
-                <input type="hidden" th:field="*{viewerCount}" value="1">
+                <input type="hidden" th:field="*{viewerCount}">
                 <button type="submit">저장</button>
             </form>
             <a href="/notice/list">목록으로 돌아가기</a>

--- a/src/main/resources/templates/function/notice_board/list.html
+++ b/src/main/resources/templates/function/notice_board/list.html
@@ -142,7 +142,7 @@
                 <td>
                     <a th:href="@{/notice/{noticeNo}(noticeNo=${notice.noticeNo})}" th:text="${notice.noticeTitle}"></a>
                 </td>
-                <td th:text="${notice.employeeNo}"></td>
+                <td th:text="${notice.employeeName}"></td>
                 <td th:text="${#temporals.format(notice.noticeDate, 'yyyy-MM-dd HH:mm')}"></td>
                 <td th:text="${notice.viewerCount}"></td>
 

--- a/src/main/resources/templates/function/notice_board/view.html
+++ b/src/main/resources/templates/function/notice_board/view.html
@@ -68,12 +68,14 @@
 
         <article class="main-content">
 
-            <h1 th:text="${notice.noticeTitle}"></h1>
-            <p>Notice No: <span th:text="${notice.noticeNo}"></span></p>
-            <p>Vote: <span th:text="${notice.noticeVote}"></span></p>
+            <p>번호: <span th:text="${notice.noticeNo}"></span></p>
+            <p>제목: <span th:text="${notice.noticeTitle}"></span></p>
+            <p>글종류: <span th:text="${notice.noticeVote == 0 ? '공지' : (notice.noticeVote == 1 ? '투표' : '완료')}"></span></p>
             <p>작성일: <span th:text="${#temporals.format(notice.noticeDate, 'yyyy-MM-dd HH:mm')}"></span></p>
-            <p>조회수: <span th:text="${notice.viewerCount}"></span></p>
             <p>작성자: <span th:text="${notice.employeeName}"></span></p>
+            <p>조회수: <span th:text="${notice.viewerCount}"></span></p>
+
+            <p>내용</p>
             <div th:utext="${notice.noticeContent}"></div>
             <a th:href="@{/notices/{noticeNo}/edit(noticeNo=${notice.noticeNo})}">수정</a>
             <form th:action="@{/notices/{noticeNo}/delete(noticeNo=${notice.noticeNo})}" method="post" style="display: inline;">

--- a/src/main/resources/templates/function/notice_board/view.html
+++ b/src/main/resources/templates/function/notice_board/view.html
@@ -73,7 +73,7 @@
             <p>Vote: <span th:text="${notice.noticeVote}"></span></p>
             <p>작성일: <span th:text="${#temporals.format(notice.noticeDate, 'yyyy-MM-dd HH:mm')}"></span></p>
             <p>조회수: <span th:text="${notice.viewerCount}"></span></p>
-            <p>작성자 사번: <span th:text="${notice.employeeNo}"></span></p>
+            <p>작성자: <span th:text="${notice.employeeName}"></span></p>
             <div th:utext="${notice.noticeContent}"></div>
             <a th:href="@{/notices/{noticeNo}/edit(noticeNo=${notice.noticeNo})}">수정</a>
             <form th:action="@{/notices/{noticeNo}/delete(noticeNo=${notice.noticeNo})}" method="post" style="display: inline;">


### PR DESCRIPTION
## #️⃣ Issue Number

#163 

## 📝 요약(Summary)

로그인 정보 받아오기 관련 오류 해결(쿼리에서 select 컬럼 누락문제)
글쓰기에 작성자(로그인 한 사원 정보)session에서 받아와서 주입
글보기에 글 종류 변화해서 보여줌

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
![글내용에 글종류 코드가 아닌 명칭으로 변환](https://github.com/user-attachments/assets/77e873e4-2a10-42b7-9edb-3cabbec5369d)
![작성자 주입](https://github.com/user-attachments/assets/01da07c1-4123-499f-a56d-d52535cb0ab4)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
